### PR TITLE
Ubuntu 上でも動くよう変更しました

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 riscv_emulator: display_function.o riscv_assembler.o riscv_emulator.o
-	gcc -Wall -o emu display_function.o riscv_assembler.o riscv_emulator.o 
+	gcc -g3 -Wall -o emu display_function.o riscv_assembler.o riscv_emulator.o -lm
 
 
 riscv_assembler.o: riscv_assembler.c
-	gcc -c riscv_assembler.c
+	gcc -g3 -c riscv_assembler.c
 
 
 display_function.o: display_function.c
-	gcc -c display_function.c
+	gcc -g3 -c display_function.c
 
 
 riscv_emulator.o: riscv_emulator.c
-	gcc -c riscv_emulator.c
+	gcc -g3 -c riscv_emulator.c
 
 
 clean:

--- a/riscv_emulator.c
+++ b/riscv_emulator.c
@@ -53,8 +53,8 @@ int main(int argc, char *argv[]){
   int num_of_inst2 = 0;
   char raw_inst[64];
   FILE *inst_output; //instruction
-  scanf("%s", srcfile_name);
-  if (strcmp(srcfile_name, "r") != 0){
+  scanf("%63s", srcfile_name);
+  if (strcmp(srcfile_name, "n") != 0){
     src_flag = 1;
     FILE *fq = fopen(srcfile_name, "r");
     if (!fq){
@@ -82,9 +82,19 @@ int main(int argc, char *argv[]){
         num_of_label += 1;
       }
     }
+
+    /* WSL の Ubuntu でも動くようにエラー処理を追加 */
     inst_output = fopen("/dev/ttys003", "w");
-    fprintf(stderr, "\n");
-    fprintf(inst_output, "\n");
+    if (inst_output != NULL) {
+        fprintf(stderr, "\n");
+        fprintf(inst_output, "\n");
+    } else {
+        fprintf(stderr, "error: fopen(\"/dev/ttys003\")\n");
+        fprintf(stderr, "intead, trying opening \"/dev/tty3\"...\n\n");
+        inst_output = fopen("/dev/tty3", "w");
+        if (inst_output == NULL) exit(1);
+    }
+
   }
 
   for (int i = 0; i < 512; i++){


### PR DESCRIPTION
1. Ubuntu 上でも動くよう "/dev/ttys3" が開けないときには "/dev/tty3" を開くよう変更しました.
もしかしたら Mac で動かなくなってる可能性もあるかもしれないので一応確認お願いします.
2. 同じく Ubuntu でも動くようにコンパイルオプションに -lm を追加しました.
3. 最初のメッセージをスキップするコマンドが 'r' になっていたのを修正しました.